### PR TITLE
Adding additional values for Kong deployments

### DIFF
--- a/charts/apiclarity/templates/_helpers.tpl
+++ b/charts/apiclarity/templates/_helpers.tpl
@@ -15,3 +15,14 @@ Helm labels.
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "apiclarity.serviceAccountName" -}}
+{{- if .Values.apiclarity.serviceAccount.create -}}
+    {{ default (include "apiclarity.name" .) .Values.apiclarity.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.apiclarity.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/apiclarity/templates/clusterrole.yaml
+++ b/charts/apiclarity/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.apiclarity.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -8,3 +9,4 @@ rules:
 - apiGroups: [""]
   resources: ["nodes", "services"]
   verbs: ["get", "list", "watch"]
+{{- end -}}

--- a/charts/apiclarity/templates/clusterrolebinding.yaml
+++ b/charts/apiclarity/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.apiclarity.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,5 +11,6 @@ roleRef:
   name: {{ include "apiclarity.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "apiclarity.name" . }}
+    name: {{ include "apiclarity.serviceAccountName" . }}
     namespace: '{{ .Release.Namespace }}'
+{{- end -}}

--- a/charts/apiclarity/templates/deployment.yaml
+++ b/charts/apiclarity/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: {{ include "apiclarity.name" . }}
+      serviceAccountName: {{ include "apiclarity.serviceAccountName" . }}
       initContainers:
         - name: '{{ include "apiclarity.name" . }}-wait-for-db'
           image: docker.io/bitnami/postgresql:11.13.0-debian-10-r33
@@ -27,6 +27,8 @@ spec:
             do echo waiting for database; sleep 2; done;']
           securityContext:
             runAsUser: 1001
+          resources:
+          {{- toYaml .Values.apiclarity.initResources | nindent 12 }}
       containers:
         - name: apiclarity
           image: '{{ .Values.global.docker.registry }}/apiclarity:{{ .Values.apiclarity.docker.imageTag }}'
@@ -89,12 +91,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           resources:
-            requests:
-              memory: "200Mi"
-              cpu: "100m"
-            limits:
-              memory: "1000Mi"
-              cpu: "1000m"
+          {{- toYaml .Values.apiclarity.resources | nindent 12 }}
           volumeMounts:
             - name: {{ include "apiclarity.name" . }}
               mountPath: '/apiclarity'

--- a/charts/apiclarity/templates/post-install-job-kong.yaml
+++ b/charts/apiclarity/templates/post-install-job-kong.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.trafficSource.kong.enabled }}
+{{- if and .Values.trafficSource.kong.enabled .Values.trafficSource.kong.patch }}
+{{- if .Values.apiclarity.rbac.create -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -19,6 +20,7 @@ rules:
 - apiGroups: ["configuration.konghq.com"]
   resources: ["kongplugins"]
   verbs: ["get", "list", "create", "patch"]
+{{- end -}}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -30,6 +32,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+{{- if .Values.apiclarity.rbac.create -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -48,6 +51,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "apiclarity.name" . }}-kong-post-install-job
     namespace: '{{ .Release.Namespace }}'
+{{- end -}}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/charts/apiclarity/templates/serviceaccount.yaml
+++ b/charts/apiclarity/templates/serviceaccount.yaml
@@ -1,7 +1,9 @@
+{{- if .Values.apiclarity.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "apiclarity.name" . }}
+  name: {{ include "apiclarity.serviceAccountName" . }}
   namespace: '{{ .Release.Namespace }}'
   labels:
     {{ include "apiclarity.labels" . }}
+{{- end -}}

--- a/charts/apiclarity/templates/traffic_sources/tap/clusterrole.yaml
+++ b/charts/apiclarity/templates/traffic_sources/tap/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.trafficSource.tap.enabled }}
+{{- if and .Values.trafficSource.tap.enabled .Values.apiclarity.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/apiclarity/templates/traffic_sources/tap/clusterrolebinding.yaml
+++ b/charts/apiclarity/templates/traffic_sources/tap/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.trafficSource.tap.enabled }}
+{{- if and .Values.trafficSource.tap.enabled .Values.apiclarity.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/apiclarity/values.yaml
+++ b/charts/apiclarity/values.yaml
@@ -43,6 +43,35 @@ apiclarity:
   ## Logging level (debug, info, warning, error, fatal, panic).
   logLevel: warning
 
+  ## Enable/disable rbac resource creation (i.e. ClusterRole, ClusterRoleBinding)
+  rbac:
+    create: true
+
+  ## ServiceAccount settings
+  serviceAccount:
+    ## Enable/disable ServiceAccount creation. Set false to use a pre-existing account
+    create: true
+    ## Override name of ServiceAccount
+    # name:
+
+  ## Resource limits for APIClarity deployment
+  resources:
+    requests:
+      memory: "200Mi"
+      cpu: "100m"
+    limits:
+      memory: "1000Mi"
+      cpu: "1000m"
+
+  ## Resource limits for APIClarity init container deployment
+  initResources:
+    requests:
+      memory: "200Mi"
+      cpu: "100m"
+    limits:
+      memory: "1000Mi"
+      cpu: "200m"
+
 ## End of APIClarity Values
 #######################################################################################
 
@@ -118,6 +147,9 @@ trafficSource:
     ## Enable Kong traffic source
     ##
     enabled: false
+
+    ## Carry out post-install patching of kong container to install plugin
+    patch: true
 
     ## Specify the name of the proxy container in Kong gateway to patch
     ##


### PR DESCRIPTION
- Added "rbac.create" boolean option. If set to "false" will disable creation of all CR/CRBs. Defaults to true
- Added "serviceAccount.create" boolean option. If set to "false" the service account will not be created. Defaults to true
- Added "resources" value. Allows overriding default resource limits/requests for all api-clarity containers.
- Added "trafficSource.kong.patch" boolean option. If set to false the postinstall Job will be skipped entirely and only the api-clarity containers will be installed. Defaults to true.