### PR TITLE
helm: fix pvc empty storageClassName support

### DIFF
--- a/charts/apiclarity/templates/pvc.yaml
+++ b/charts/apiclarity/templates/pvc.yaml
@@ -12,5 +12,9 @@ spec:
     requests:
       storage: '{{ .Values.global.persistentVolume.size }}'
 {{- if .Values.global.persistentVolume.storageClass }}
+{{- if (eq "-" .Values.global.persistentVolume.storageClass) }}
+  storageClassName: ""
+{{- else }}
   storageClassName: '{{ .Values.global.persistentVolume.storageClass }}'
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Per the comment in the values file `If set to "-", storageClassName: "", which disables dynamic provisioning`
https://github.com/apiclarity/apiclarity/blob/master/charts/apiclarity/values.yaml#L25

may fix https://github.com/apiclarity/apiclarity/issues/97