### PR TITLE
Trace file bad format

### DIFF
--- a/backend/pkg/backend/fake.go
+++ b/backend/pkg/backend/fake.go
@@ -82,6 +82,9 @@ func (b *Backend) handleHTTPTraceFromFile(fileName string) error {
 	if err := json.Unmarshal(byteValue, &trace); err != nil {
 		return fmt.Errorf("failed to unmarshal. %v", err)
 	}
+	if trace.Request == nil || trace.Request.Common == nil || trace.Response == nil || trace.Response.Common == nil {
+		return fmt.Errorf("failed to handle trace for file: %v. Bad format", fileName)
+	}
 	if err := b.handleHTTPTrace(&trace); err != nil {
 		return fmt.Errorf("failed to handle trace for file: %v. %v", fileName, err)
 	}

--- a/backend/pkg/test/trace_files/httpbin_get_1234_headers.json
+++ b/backend/pkg/test/trace_files/httpbin_get_1234_headers.json
@@ -1,69 +1,73 @@
-
 {
-  "request_id": "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd7",
+  "requestID": "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd7",
   "scheme": "",
-  "destination_address": "10.116.207.196:8000",
-  "source_address": "10.116.207.197:8000",
-  "scnt_request": {
+  "destinationAddress": "10.116.207.196:8000",
+  "destinationNamespace": null,
+  "sourceAddress": "10.116.207.197:8000",
+  "request": {
     "method": "GET",
     "path": "/1234/headers",
     "host": "",
-    "version": "",
-    "headers": [
-      [
-        "host",
-        "httpbin:8000"
+    "common": {
+      "version": null,
+      "headers": [
+        {
+          "key": "host",
+          "value": "httpbin:8000"
+        },
+        {
+          "key": "user-agent",
+          "value": "curl/7.35.0"
+        },
+        {
+          "key": "accept",
+          "value": "application/json"
+        },
+        {
+          "key": "x-forwarded-proto",
+          "value": "http"
+        },
+        {
+          "key": "x-request-id",
+          "value": "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd4"
+        }
       ],
-      [
-        "user-agent",
-        "curl/7.35.0"
-      ],
-      [
-        "accept",
-        "application/json"
-      ],
-      [
-        "x-forwarded-proto",
-        "http"
-      ],
-      [
-        "x-request-id",
-        "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd4"
-      ]
-    ],
-    "body": "",
-    "truncated_body": false
+      "body": "",
+      "TruncatedBody": false
+    }
   },
-  "scnt_response": {
-    "status_code": "200",
-    "version": "",
-    "headers": [
-      [
-        "server",
-        "istio-envoy"
+  "response": {
+    "statusCode": "200",
+    "common": {
+      "version": "",
+      "headers": [
+        {
+          "key": "server",
+          "value": "istio-envoy"
+        },
+        {
+          "key": "date",
+          "value": "Mon, 16 Aug 2021 10:44:10 GMT"
+        },
+        {
+          "key": "content-type",
+          "value": "application/json"
+        },
+        {
+          "key": "content-length",
+          "value": "543"
+        },
+        {
+          "key": "access-control-allow-origin",
+          "value": "*"
+        },
+        {
+          "key": "access-control-allow-credentials",
+          "value": "true"
+        }
       ],
-      [
-        "date",
-        "Mon, 16 Aug 2021 10:44:10 GMT"
-      ],
-      [
-        "content-type",
-        "application/json"
-      ],
-      [
-        "content-length",
-        "543"
-      ],
-      [
-        "access-control-allow-origin",
-        "*"
-      ],
-      [
-        "access-control-allow-credentials",
-        "true"
-      ]
-    ],
-    "body": "ewogICJoZWFkZXJzIjogewogICAgIkFjY2VwdCI6ICJhcHBsaWNhdGlvbi9qc29uIiwgCiAgICAiSG9zdCI6ICJodHRwYmluOjgwMDAiLCAKICAgICJVc2VyLUFnZW50IjogImN1cmwvNy4zNS4wIiwgCiAgICAiWC1CMy1QYXJlbnRzcGFuaWQiOiAiYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtQjMtU2FtcGxlZCI6ICIxIiwgCiAgICAiWC1CMy1TcGFuaWQiOiAiZDEwYTI2OWM1YjA1ZWM3ZSIsIAogICAgIlgtQjMtVHJhY2VpZCI6ICJjZWE3OTJmZjA1N2UxYmNkYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtRW52b3ktQXR0ZW1wdC1Db3VudCI6ICIxIiwgCiAgICAiWC1Gb3J3YXJkZWQtQ2xpZW50LUNlcnQiOiAiQnk9c3BpZmZlOi8vY2x1c3Rlci5sb2NhbC9ucy90cmFjZXMtdGVzdC9zYS9odHRwYmluO0hhc2g9NmMyYjE5M2Y1ZmJhMGEyZjM4ZjU0MDcwYTZiZDAwNzRlZGJjYmVkZTc4ODM5ODBiYWEyZjY2ODEyZTQ2Mjg4ZTtTdWJqZWN0PVwiXCI7VVJJPXNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMvdHJhY2VzLXRlc3Qvc2EvY3VybCIKICB9Cn0K",
-    "truncated_body": false
+      "body": "ewogICJoZWFkZXJzIjogewogICAgIkFjY2VwdCI6ICJhcHBsaWNhdGlvbi9qc29uIiwgCiAgICAiSG9zdCI6ICJodHRwYmluOjgwMDAiLCAKICAgICJVc2VyLUFnZW50IjogImN1cmwvNy4zNS4wIiwgCiAgICAiWC1CMy1QYXJlbnRzcGFuaWQiOiAiYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtQjMtU2FtcGxlZCI6ICIxIiwgCiAgICAiWC1CMy1TcGFuaWQiOiAiZDEwYTI2OWM1YjA1ZWM3ZSIsIAogICAgIlgtQjMtVHJhY2VpZCI6ICJjZWE3OTJmZjA1N2UxYmNkYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtRW52b3ktQXR0ZW1wdC1Db3VudCI6ICIxIiwgCiAgICAiWC1Gb3J3YXJkZWQtQ2xpZW50LUNlcnQiOiAiQnk9c3BpZmZlOi8vY2x1c3Rlci5sb2NhbC9ucy90cmFjZXMtdGVzdC9zYS9odHRwYmluO0hhc2g9NmMyYjE5M2Y1ZmJhMGEyZjM4ZjU0MDcwYTZiZDAwNzRlZGJjYmVkZTc4ODM5ODBiYWEyZjY2ODEyZTQ2Mjg4ZTtTdWJqZWN0PVwiXCI7VVJJPXNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMvdHJhY2VzLXRlc3Qvc2EvY3VybCIKICB9Cn0K",
+      "TruncatedBody": false
+    }
   }
 }

--- a/backend/pkg/test/trace_files/httpbin_get_anything.json
+++ b/backend/pkg/test/trace_files/httpbin_get_anything.json
@@ -1,68 +1,73 @@
 {
-  "request_id": "e34fe93d-ba40-9467-baa3-97936eb57471",
+  "requestID": "e34fe93d-ba40-9467-baa3-97936eb57471",
   "scheme": "",
-  "destination_address": "10.116.207.196:8000",
-  "source_address": "10.116.207.197:8000",
-  "scnt_request": {
+  "destinationAddress": "10.116.207.196:8000",
+  "destinationNamespace": null,
+  "sourceAddress": "10.116.207.197:8000",
+  "request": {
     "method": "GET",
     "path": "/anything",
     "host": "",
-    "version": "",
-    "headers": [
-      [
-        "host",
-        "httpbin:8000"
+    "common": {
+      "version": null,
+      "headers": [
+        {
+          "key": "host",
+          "value": "httpbin:8000"
+        },
+        {
+          "key": "user-agent",
+          "value": "curl/7.35.0"
+        },
+        {
+          "key": "accept",
+          "value": "application/json"
+        },
+        {
+          "key": "x-forwarded-proto",
+          "value": "http"
+        },
+        {
+          "key": "x-request-id",
+          "value": "e34fe93d-ba40-9467-baa3-97936eb57478"
+        }
       ],
-      [
-        "user-agent",
-        "curl/7.35.0"
-      ],
-      [
-        "accept",
-        "application/json"
-      ],
-      [
-        "x-forwarded-proto",
-        "http"
-      ],
-      [
-        "x-request-id",
-        "e34fe93d-ba40-9467-baa3-97936eb57478"
-      ]
-    ],
-    "body": "",
-    "truncated_body": false
+      "body": "",
+      "TruncatedBody": false
+    }
   },
-  "scnt_response": {
-    "status_code": "200",
-    "version": "",
-    "headers": [
-      [
-        "server",
-        "istio-envoy"
+  "response": {
+    "statusCode": "200",
+    "common": {
+      "version": "",
+      "headers": [
+        {
+          "key": "server",
+          "value": "istio-envoy"
+        },
+        {
+          "key": "date",
+          "value": "Mon, 16 Aug 2021 10:40:41 GMT"
+        },
+        {
+          "key": "content-type",
+          "value": "application/json"
+        },
+        {
+          "key": "content-length",
+          "value": "709"
+        },
+        {
+          "key": "access-control-allow-origin",
+          "value": "*"
+        },
+        {
+          "key": "access-control-allow-credentials",
+          "value": "true"
+        }
       ],
-      [
-        "date",
-        "Mon, 16 Aug 2021 10:40:41 GMT"
-      ],
-      [
-        "content-type",
-        "application/json"
-      ],
-      [
-        "content-length",
-        "709"
-      ],
-      [
-        "access-control-allow-origin",
-        "*"
-      ],
-      [
-        "access-control-allow-credentials",
-        "true"
-      ]
-    ],
-    "body": "ewogICJhcmdzIjoge30sIAogICJkYXRhIjogIiIsIAogICJmaWxlcyI6IHt9LCAKICAiZm9ybSI6IHt9LCAKICAiaGVhZGVycyI6IHsKICAgICJBY2NlcHQiOiAiYXBwbGljYXRpb24vanNvbiIsIAogICAgIkhvc3QiOiAiaHR0cGJpbjo4MDAwIiwgCiAgICAiVXNlci1BZ2VudCI6ICJjdXJsLzcuMzUuMCIsIAogICAgIlgtQjMtUGFyZW50c3BhbmlkIjogImFmMGQ4NzM2YzNlMTFmYzciLCAKICAgICJYLUIzLVNhbXBsZWQiOiAiMSIsIAogICAgIlgtQjMtU3BhbmlkIjogImIzNjJhM2NiY2JiYzg3MWIiLCAKICAgICJYLUIzLVRyYWNlaWQiOiAiMDM1MzFkNDMyYTFhYzZjOGFmMGQ4NzM2YzNlMTFmYzciLCAKICAgICJYLUVudm95LUF0dGVtcHQtQ291bnQiOiAiMSIsIAogICAgIlgtRm9yd2FyZGVkLUNsaWVudC1DZXJ0IjogIkJ5PXNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMvdHJhY2VzLXRlc3Qvc2EvaHR0cGJpbjtIYXNoPTZjMmIxOTNmNWZiYTBhMmYzOGY1NDA3MGE2YmQwMDc0ZWRiY2JlZGU3ODgzOTgwYmFhMmY2NjgxMmU0NjI4OGU7U3ViamVjdD1cIlwiO1VSST1zcGlmZmU6Ly9jbHVzdGVyLmxvY2FsL25zL3RyYWNlcy10ZXN0L3NhL2N1cmwiCiAgfSwgCiAgImpzb24iOiBudWxsLCAKICAibWV0aG9kIjogIkdFVCIsIAogICJvcmlnaW4iOiAiMTI3LjAuMC42IiwgCiAgInVybCI6ICJodHRwOi8vaHR0cGJpbjo4MDAwL2FueXRoaW5nIgp9Cg==",
-    "truncated_body": false
+      "body": "ewogICJhcmdzIjoge30sIAogICJkYXRhIjogIiIsIAogICJmaWxlcyI6IHt9LCAKICAiZm9ybSI6IHt9LCAKICAiaGVhZGVycyI6IHsKICAgICJBY2NlcHQiOiAiYXBwbGljYXRpb24vanNvbiIsIAogICAgIkhvc3QiOiAiaHR0cGJpbjo4MDAwIiwgCiAgICAiVXNlci1BZ2VudCI6ICJjdXJsLzcuMzUuMCIsIAogICAgIlgtQjMtUGFyZW50c3BhbmlkIjogImFmMGQ4NzM2YzNlMTFmYzciLCAKICAgICJYLUIzLVNhbXBsZWQiOiAiMSIsIAogICAgIlgtQjMtU3BhbmlkIjogImIzNjJhM2NiY2JiYzg3MWIiLCAKICAgICJYLUIzLVRyYWNlaWQiOiAiMDM1MzFkNDMyYTFhYzZjOGFmMGQ4NzM2YzNlMTFmYzciLCAKICAgICJYLUVudm95LUF0dGVtcHQtQ291bnQiOiAiMSIsIAogICAgIlgtRm9yd2FyZGVkLUNsaWVudC1DZXJ0IjogIkJ5PXNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMvdHJhY2VzLXRlc3Qvc2EvaHR0cGJpbjtIYXNoPTZjMmIxOTNmNWZiYTBhMmYzOGY1NDA3MGE2YmQwMDc0ZWRiY2JlZGU3ODgzOTgwYmFhMmY2NjgxMmU0NjI4OGU7U3ViamVjdD1cIlwiO1VSST1zcGlmZmU6Ly9jbHVzdGVyLmxvY2FsL25zL3RyYWNlcy10ZXN0L3NhL2N1cmwiCiAgfSwgCiAgImpzb24iOiBudWxsLCAKICAibWV0aG9kIjogIkdFVCIsIAogICJvcmlnaW4iOiAiMTI3LjAuMC42IiwgCiAgInVybCI6ICJodHRwOi8vaHR0cGJpbjo4MDAwL2FueXRoaW5nIgp9Cg==",
+      "TruncatedBody": false
+    }
   }
 }

--- a/backend/pkg/test/trace_files/httpbin_get_anything_three_parts.json
+++ b/backend/pkg/test/trace_files/httpbin_get_anything_three_parts.json
@@ -1,68 +1,73 @@
 {
-  "request_id": "e34fe93d-ba40-9467-baa3-97936eb57472",
+  "requestID": "e34fe93d-ba40-9467-baa3-97936eb57472",
   "scheme": "",
-  "destination_address": "10.116.207.196:8000",
-  "source_address": "10.116.207.197:8000",
-  "scnt_request": {
+  "destinationAddress": "10.116.207.196:8000",
+  "destinationNamespace": null,
+  "sourceAddress": "10.116.207.197:8000",
+  "request": {
     "method": "GET",
     "path": "/anything/three/parts",
     "host": "",
-    "version": "",
-    "headers": [
-      [
-        "host",
-        "httpbin:8000"
+    "common": {
+      "version": null,
+      "headers": [
+        {
+          "key": "host",
+          "value": "httpbin:8000"
+        },
+        {
+          "key": "user-agent",
+          "value": "curl/7.35.0"
+        },
+        {
+          "key": "accept",
+          "value": "application/json"
+        },
+        {
+          "key": "x-forwarded-proto",
+          "value": "http"
+        },
+        {
+          "key": "x-request-id",
+          "value": "e34fe93d-ba40-9467-baa3-97936eb57478"
+        }
       ],
-      [
-        "user-agent",
-        "curl/7.35.0"
-      ],
-      [
-        "accept",
-        "application/json"
-      ],
-      [
-        "x-forwarded-proto",
-        "http"
-      ],
-      [
-        "x-request-id",
-        "e34fe93d-ba40-9467-baa3-97936eb57478"
-      ]
-    ],
-    "body": "",
-    "truncated_body": false
+      "body": "",
+      "TruncatedBody": false
+    }
   },
-  "scnt_response": {
-    "status_code": "200",
-    "version": "",
-    "headers": [
-      [
-        "server",
-        "istio-envoy"
+  "response": {
+    "statusCode": "200",
+    "common": {
+      "version": "",
+      "headers": [
+        {
+          "key": "server",
+          "value": "istio-envoy"
+        },
+        {
+          "key": "date",
+          "value": "Mon, 16 Aug 2021 10:40:41 GMT"
+        },
+        {
+          "key": "content-type",
+          "value": "application/json"
+        },
+        {
+          "key": "content-length",
+          "value": "709"
+        },
+        {
+          "key": "access-control-allow-origin",
+          "value": "*"
+        },
+        {
+          "key": "access-control-allow-credentials",
+          "value": "true"
+        }
       ],
-      [
-        "date",
-        "Mon, 16 Aug 2021 10:40:41 GMT"
-      ],
-      [
-        "content-type",
-        "application/json"
-      ],
-      [
-        "content-length",
-        "709"
-      ],
-      [
-        "access-control-allow-origin",
-        "*"
-      ],
-      [
-        "access-control-allow-credentials",
-        "true"
-      ]
-    ],
-    "body": "ewogICJhcmdzIjoge30sIAogICJkYXRhIjogIiIsIAogICJmaWxlcyI6IHt9LCAKICAiZm9ybSI6IHt9LCAKICAiaGVhZGVycyI6IHsKICAgICJBY2NlcHQiOiAiYXBwbGljYXRpb24vanNvbiIsIAogICAgIkhvc3QiOiAiaHR0cGJpbjo4MDAwIiwgCiAgICAiVXNlci1BZ2VudCI6ICJjdXJsLzcuMzUuMCIsIAogICAgIlgtQjMtUGFyZW50c3BhbmlkIjogImFmMGQ4NzM2YzNlMTFmYzciLCAKICAgICJYLUIzLVNhbXBsZWQiOiAiMSIsIAogICAgIlgtQjMtU3BhbmlkIjogImIzNjJhM2NiY2JiYzg3MWIiLCAKICAgICJYLUIzLVRyYWNlaWQiOiAiMDM1MzFkNDMyYTFhYzZjOGFmMGQ4NzM2YzNlMTFmYzciLCAKICAgICJYLUVudm95LUF0dGVtcHQtQ291bnQiOiAiMSIsIAogICAgIlgtRm9yd2FyZGVkLUNsaWVudC1DZXJ0IjogIkJ5PXNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMvdHJhY2VzLXRlc3Qvc2EvaHR0cGJpbjtIYXNoPTZjMmIxOTNmNWZiYTBhMmYzOGY1NDA3MGE2YmQwMDc0ZWRiY2JlZGU3ODgzOTgwYmFhMmY2NjgxMmU0NjI4OGU7U3ViamVjdD1cIlwiO1VSST1zcGlmZmU6Ly9jbHVzdGVyLmxvY2FsL25zL3RyYWNlcy10ZXN0L3NhL2N1cmwiCiAgfSwgCiAgImpzb24iOiBudWxsLCAKICAibWV0aG9kIjogIkdFVCIsIAogICJvcmlnaW4iOiAiMTI3LjAuMC42IiwgCiAgInVybCI6ICJodHRwOi8vaHR0cGJpbjo4MDAwL2FueXRoaW5nIgp9Cg==",
-    "truncated_body": false
+      "body": "ewogICJhcmdzIjoge30sIAogICJkYXRhIjogIiIsIAogICJmaWxlcyI6IHt9LCAKICAiZm9ybSI6IHt9LCAKICAiaGVhZGVycyI6IHsKICAgICJBY2NlcHQiOiAiYXBwbGljYXRpb24vanNvbiIsIAogICAgIkhvc3QiOiAiaHR0cGJpbjo4MDAwIiwgCiAgICAiVXNlci1BZ2VudCI6ICJjdXJsLzcuMzUuMCIsIAogICAgIlgtQjMtUGFyZW50c3BhbmlkIjogImFmMGQ4NzM2YzNlMTFmYzciLCAKICAgICJYLUIzLVNhbXBsZWQiOiAiMSIsIAogICAgIlgtQjMtU3BhbmlkIjogImIzNjJhM2NiY2JiYzg3MWIiLCAKICAgICJYLUIzLVRyYWNlaWQiOiAiMDM1MzFkNDMyYTFhYzZjOGFmMGQ4NzM2YzNlMTFmYzciLCAKICAgICJYLUVudm95LUF0dGVtcHQtQ291bnQiOiAiMSIsIAogICAgIlgtRm9yd2FyZGVkLUNsaWVudC1DZXJ0IjogIkJ5PXNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMvdHJhY2VzLXRlc3Qvc2EvaHR0cGJpbjtIYXNoPTZjMmIxOTNmNWZiYTBhMmYzOGY1NDA3MGE2YmQwMDc0ZWRiY2JlZGU3ODgzOTgwYmFhMmY2NjgxMmU0NjI4OGU7U3ViamVjdD1cIlwiO1VSST1zcGlmZmU6Ly9jbHVzdGVyLmxvY2FsL25zL3RyYWNlcy10ZXN0L3NhL2N1cmwiCiAgfSwgCiAgImpzb24iOiBudWxsLCAKICAibWV0aG9kIjogIkdFVCIsIAogICJvcmlnaW4iOiAiMTI3LjAuMC42IiwgCiAgInVybCI6ICJodHRwOi8vaHR0cGJpbjo4MDAwL2FueXRoaW5nIgp9Cg==",
+      "TruncatedBody": false
+    }
   }
 }

--- a/backend/pkg/test/trace_files/httpbin_get_headers.json
+++ b/backend/pkg/test/trace_files/httpbin_get_headers.json
@@ -1,68 +1,73 @@
 {
-  "request_id": "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd4",
+  "requestID": "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd4",
   "scheme": "",
-  "destination_address": "10.116.207.196:8000",
-  "source_address": "10.116.207.197:8000",
-  "scnt_request": {
+  "destinationAddress": "10.116.207.196:8000",
+  "destinationNamespace": null,
+  "sourceAddress": "10.116.207.197:8000",
+  "request": {
     "method": "GET",
     "path": "/headers",
     "host": "",
-    "version": "",
-    "headers": [
-      [
-        "host",
-        "httpbin:8000"
+    "common": {
+      "version": null,
+      "headers": [
+        {
+          "key": "host",
+          "value": "httpbin:8000"
+        },
+        {
+          "key": "user-agent",
+          "value": "curl/7.35.0"
+        },
+        {
+          "key": "accept",
+          "value": "application/json"
+        },
+        {
+          "key": "x-forwarded-proto",
+          "value": "http"
+        },
+        {
+          "key": "x-request-id",
+          "value": "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd4"
+        }
       ],
-      [
-        "user-agent",
-        "curl/7.35.0"
-      ],
-      [
-        "accept",
-        "application/json"
-      ],
-      [
-        "x-forwarded-proto",
-        "http"
-      ],
-      [
-        "x-request-id",
-        "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd4"
-      ]
-    ],
-    "body": "",
-    "truncated_body": false
+      "body": "",
+      "TruncatedBody": false
+    }
   },
-  "scnt_response": {
-    "status_code": "200",
-    "version": "",
-    "headers": [
-      [
-        "server",
-        "istio-envoy"
+  "response": {
+    "statusCode": "200",
+    "common": {
+      "version": "",
+      "headers": [
+        {
+          "key": "server",
+          "value": "istio-envoy"
+        },
+        {
+          "key": "date",
+          "value": "Mon, 16 Aug 2021 10:44:10 GMT"
+        },
+        {
+          "key": "content-type",
+          "value": "application/json"
+        },
+        {
+          "key": "content-length",
+          "value": "543"
+        },
+        {
+          "key": "access-control-allow-origin",
+          "value": "*"
+        },
+        {
+          "key": "access-control-allow-credentials",
+          "value": "true"
+        }
       ],
-      [
-        "date",
-        "Mon, 16 Aug 2021 10:44:10 GMT"
-      ],
-      [
-        "content-type",
-        "application/json"
-      ],
-      [
-        "content-length",
-        "543"
-      ],
-      [
-        "access-control-allow-origin",
-        "*"
-      ],
-      [
-        "access-control-allow-credentials",
-        "true"
-      ]
-    ],
-    "body": "ewogICJoZWFkZXJzIjogewogICAgIkFjY2VwdCI6ICJhcHBsaWNhdGlvbi9qc29uIiwgCiAgICAiSG9zdCI6ICJodHRwYmluOjgwMDAiLCAKICAgICJVc2VyLUFnZW50IjogImN1cmwvNy4zNS4wIiwgCiAgICAiWC1CMy1QYXJlbnRzcGFuaWQiOiAiYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtQjMtU2FtcGxlZCI6ICIxIiwgCiAgICAiWC1CMy1TcGFuaWQiOiAiZDEwYTI2OWM1YjA1ZWM3ZSIsIAogICAgIlgtQjMtVHJhY2VpZCI6ICJjZWE3OTJmZjA1N2UxYmNkYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtRW52b3ktQXR0ZW1wdC1Db3VudCI6ICIxIiwgCiAgICAiWC1Gb3J3YXJkZWQtQ2xpZW50LUNlcnQiOiAiQnk9c3BpZmZlOi8vY2x1c3Rlci5sb2NhbC9ucy90cmFjZXMtdGVzdC9zYS9odHRwYmluO0hhc2g9NmMyYjE5M2Y1ZmJhMGEyZjM4ZjU0MDcwYTZiZDAwNzRlZGJjYmVkZTc4ODM5ODBiYWEyZjY2ODEyZTQ2Mjg4ZTtTdWJqZWN0PVwiXCI7VVJJPXNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMvdHJhY2VzLXRlc3Qvc2EvY3VybCIKICB9Cn0K",
-    "truncated_body": false
+      "body": "ewogICJoZWFkZXJzIjogewogICAgIkFjY2VwdCI6ICJhcHBsaWNhdGlvbi9qc29uIiwgCiAgICAiSG9zdCI6ICJodHRwYmluOjgwMDAiLCAKICAgICJVc2VyLUFnZW50IjogImN1cmwvNy4zNS4wIiwgCiAgICAiWC1CMy1QYXJlbnRzcGFuaWQiOiAiYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtQjMtU2FtcGxlZCI6ICIxIiwgCiAgICAiWC1CMy1TcGFuaWQiOiAiZDEwYTI2OWM1YjA1ZWM3ZSIsIAogICAgIlgtQjMtVHJhY2VpZCI6ICJjZWE3OTJmZjA1N2UxYmNkYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtRW52b3ktQXR0ZW1wdC1Db3VudCI6ICIxIiwgCiAgICAiWC1Gb3J3YXJkZWQtQ2xpZW50LUNlcnQiOiAiQnk9c3BpZmZlOi8vY2x1c3Rlci5sb2NhbC9ucy90cmFjZXMtdGVzdC9zYS9odHRwYmluO0hhc2g9NmMyYjE5M2Y1ZmJhMGEyZjM4ZjU0MDcwYTZiZDAwNzRlZGJjYmVkZTc4ODM5ODBiYWEyZjY2ODEyZTQ2Mjg4ZTtTdWJqZWN0PVwiXCI7VVJJPXNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMvdHJhY2VzLXRlc3Qvc2EvY3VybCIKICB9Cn0K",
+      "TruncatedBody": false
+    }
   }
 }

--- a/backend/pkg/test/trace_files/httpbin_get_headers_1234.json
+++ b/backend/pkg/test/trace_files/httpbin_get_headers_1234.json
@@ -1,68 +1,73 @@
 {
-  "request_id": "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd5",
+  "requestID": "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd5",
   "scheme": "",
-  "destination_address": "10.116.207.196:8000",
-  "source_address": "10.116.207.197:8000",
-  "scnt_request": {
+  "destinationAddress": "10.116.207.196:8000",
+  "destinationNamespace": null,
+  "sourceAddress": "10.116.207.197:8000",
+  "request": {
     "method": "GET",
     "path": "/headers/1234",
     "host": "",
-    "version": "",
-    "headers": [
-      [
-        "host",
-        "httpbin:8000"
+    "common": {
+      "version": null,
+      "headers": [
+        {
+          "key": "host",
+          "value": "httpbin:8000"
+        },
+        {
+          "key": "user-agent",
+          "value": "curl/7.35.0"
+        },
+        {
+          "key": "accept",
+          "value": "application/json"
+        },
+        {
+          "key": "x-forwarded-proto",
+          "value": "http"
+        },
+        {
+          "key": "x-request-id",
+          "value": "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd4"
+        }
       ],
-      [
-        "user-agent",
-        "curl/7.35.0"
-      ],
-      [
-        "accept",
-        "application/json"
-      ],
-      [
-        "x-forwarded-proto",
-        "http"
-      ],
-      [
-        "x-request-id",
-        "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd4"
-      ]
-    ],
-    "body": "",
-    "truncated_body": false
+      "body": "",
+      "TruncatedBody": false
+    }
   },
-  "scnt_response": {
-    "status_code": "200",
-    "version": "",
-    "headers": [
-      [
-        "server",
-        "istio-envoy"
+  "response": {
+    "statusCode": "200",
+    "common": {
+      "version": "",
+      "headers": [
+        {
+          "key": "server",
+          "value": "istio-envoy"
+        },
+        {
+          "key": "date",
+          "value": "Mon, 16 Aug 2021 10:44:10 GMT"
+        },
+        {
+          "key": "content-type",
+          "value": "application/json"
+        },
+        {
+          "key": "content-length",
+          "value": "543"
+        },
+        {
+          "key": "access-control-allow-origin",
+          "value": "*"
+        },
+        {
+          "key": "access-control-allow-credentials",
+          "value": "true"
+        }
       ],
-      [
-        "date",
-        "Mon, 16 Aug 2021 10:44:10 GMT"
-      ],
-      [
-        "content-type",
-        "application/json"
-      ],
-      [
-        "content-length",
-        "543"
-      ],
-      [
-        "access-control-allow-origin",
-        "*"
-      ],
-      [
-        "access-control-allow-credentials",
-        "true"
-      ]
-    ],
-    "body": "ewogICJoZWFkZXJzIjogewogICAgIkFjY2VwdCI6ICJhcHBsaWNhdGlvbi9qc29uIiwgCiAgICAiSG9zdCI6ICJodHRwYmluOjgwMDAiLCAKICAgICJVc2VyLUFnZW50IjogImN1cmwvNy4zNS4wIiwgCiAgICAiWC1CMy1QYXJlbnRzcGFuaWQiOiAiYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtQjMtU2FtcGxlZCI6ICIxIiwgCiAgICAiWC1CMy1TcGFuaWQiOiAiZDEwYTI2OWM1YjA1ZWM3ZSIsIAogICAgIlgtQjMtVHJhY2VpZCI6ICJjZWE3OTJmZjA1N2UxYmNkYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtRW52b3ktQXR0ZW1wdC1Db3VudCI6ICIxIiwgCiAgICAiWC1Gb3J3YXJkZWQtQ2xpZW50LUNlcnQiOiAiQnk9c3BpZmZlOi8vY2x1c3Rlci5sb2NhbC9ucy90cmFjZXMtdGVzdC9zYS9odHRwYmluO0hhc2g9NmMyYjE5M2Y1ZmJhMGEyZjM4ZjU0MDcwYTZiZDAwNzRlZGJjYmVkZTc4ODM5ODBiYWEyZjY2ODEyZTQ2Mjg4ZTtTdWJqZWN0PVwiXCI7VVJJPXNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMvdHJhY2VzLXRlc3Qvc2EvY3VybCIKICB9Cn0K",
-    "truncated_body": false
+      "body": "ewogICJoZWFkZXJzIjogewogICAgIkFjY2VwdCI6ICJhcHBsaWNhdGlvbi9qc29uIiwgCiAgICAiSG9zdCI6ICJodHRwYmluOjgwMDAiLCAKICAgICJVc2VyLUFnZW50IjogImN1cmwvNy4zNS4wIiwgCiAgICAiWC1CMy1QYXJlbnRzcGFuaWQiOiAiYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtQjMtU2FtcGxlZCI6ICIxIiwgCiAgICAiWC1CMy1TcGFuaWQiOiAiZDEwYTI2OWM1YjA1ZWM3ZSIsIAogICAgIlgtQjMtVHJhY2VpZCI6ICJjZWE3OTJmZjA1N2UxYmNkYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtRW52b3ktQXR0ZW1wdC1Db3VudCI6ICIxIiwgCiAgICAiWC1Gb3J3YXJkZWQtQ2xpZW50LUNlcnQiOiAiQnk9c3BpZmZlOi8vY2x1c3Rlci5sb2NhbC9ucy90cmFjZXMtdGVzdC9zYS9odHRwYmluO0hhc2g9NmMyYjE5M2Y1ZmJhMGEyZjM4ZjU0MDcwYTZiZDAwNzRlZGJjYmVkZTc4ODM5ODBiYWEyZjY2ODEyZTQ2Mjg4ZTtTdWJqZWN0PVwiXCI7VVJJPXNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMvdHJhY2VzLXRlc3Qvc2EvY3VybCIKICB9Cn0K",
+      "TruncatedBody": false
+    }
   }
 }

--- a/backend/pkg/test/trace_files/httpbin_get_headers_3456.json
+++ b/backend/pkg/test/trace_files/httpbin_get_headers_3456.json
@@ -1,68 +1,73 @@
 {
-  "request_id": "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd6",
+  "requestID": "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd6",
   "scheme": "",
-  "destination_address": "10.116.207.196:8000",
-  "source_address": "10.116.207.197:8000",
-  "scnt_request": {
+  "destinationAddress": "10.116.207.196:8000",
+  "destinationNamespace": null,
+  "sourceAddress": "10.116.207.197:8000",
+  "request": {
     "method": "GET",
     "path": "/headers/3456",
     "host": "",
-    "version": "",
-    "headers": [
-      [
-        "host",
-        "httpbin:8000"
+    "common": {
+      "version": null,
+      "headers": [
+        {
+          "key": "host",
+          "value": "httpbin:8000"
+        },
+        {
+          "key": "user-agent",
+          "value": "curl/7.35.0"
+        },
+        {
+          "key": "accept",
+          "value": "application/json"
+        },
+        {
+          "key": "x-forwarded-proto",
+          "value": "http"
+        },
+        {
+          "key": "x-request-id",
+          "value": "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd4"
+        }
       ],
-      [
-        "user-agent",
-        "curl/7.35.0"
-      ],
-      [
-        "accept",
-        "application/json"
-      ],
-      [
-        "x-forwarded-proto",
-        "http"
-      ],
-      [
-        "x-request-id",
-        "3f3c6d58-0d96-9d4a-be9f-0557eecb4dd4"
-      ]
-    ],
-    "body": "",
-    "truncated_body": false
+      "body": "",
+      "TruncatedBody": false
+    }
   },
-  "scnt_response": {
-    "status_code": "200",
-    "version": "",
-    "headers": [
-      [
-        "server",
-        "istio-envoy"
+  "response": {
+    "statusCode": "200",
+    "common": {
+      "version": "",
+      "headers": [
+        {
+          "key": "server",
+          "value": "istio-envoy"
+        },
+        {
+          "key": "date",
+          "value": "Mon, 16 Aug 2021 10:44:10 GMT"
+        },
+        {
+          "key": "content-type",
+          "value": "application/json"
+        },
+        {
+          "key": "content-length",
+          "value": "543"
+        },
+        {
+          "key": "access-control-allow-origin",
+          "value": "*"
+        },
+        {
+          "key": "access-control-allow-credentials",
+          "value": "true"
+        }
       ],
-      [
-        "date",
-        "Mon, 16 Aug 2021 10:44:10 GMT"
-      ],
-      [
-        "content-type",
-        "application/json"
-      ],
-      [
-        "content-length",
-        "543"
-      ],
-      [
-        "access-control-allow-origin",
-        "*"
-      ],
-      [
-        "access-control-allow-credentials",
-        "true"
-      ]
-    ],
-    "body": "ewogICJoZWFkZXJzIjogewogICAgIkFjY2VwdCI6ICJhcHBsaWNhdGlvbi9qc29uIiwgCiAgICAiSG9zdCI6ICJodHRwYmluOjgwMDAiLCAKICAgICJVc2VyLUFnZW50IjogImN1cmwvNy4zNS4wIiwgCiAgICAiWC1CMy1QYXJlbnRzcGFuaWQiOiAiYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtQjMtU2FtcGxlZCI6ICIxIiwgCiAgICAiWC1CMy1TcGFuaWQiOiAiZDEwYTI2OWM1YjA1ZWM3ZSIsIAogICAgIlgtQjMtVHJhY2VpZCI6ICJjZWE3OTJmZjA1N2UxYmNkYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtRW52b3ktQXR0ZW1wdC1Db3VudCI6ICIxIiwgCiAgICAiWC1Gb3J3YXJkZWQtQ2xpZW50LUNlcnQiOiAiQnk9c3BpZmZlOi8vY2x1c3Rlci5sb2NhbC9ucy90cmFjZXMtdGVzdC9zYS9odHRwYmluO0hhc2g9NmMyYjE5M2Y1ZmJhMGEyZjM4ZjU0MDcwYTZiZDAwNzRlZGJjYmVkZTc4ODM5ODBiYWEyZjY2ODEyZTQ2Mjg4ZTtTdWJqZWN0PVwiXCI7VVJJPXNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMvdHJhY2VzLXRlc3Qvc2EvY3VybCIKICB9Cn0K",
-    "truncated_body": false
+      "body": "ewogICJoZWFkZXJzIjogewogICAgIkFjY2VwdCI6ICJhcHBsaWNhdGlvbi9qc29uIiwgCiAgICAiSG9zdCI6ICJodHRwYmluOjgwMDAiLCAKICAgICJVc2VyLUFnZW50IjogImN1cmwvNy4zNS4wIiwgCiAgICAiWC1CMy1QYXJlbnRzcGFuaWQiOiAiYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtQjMtU2FtcGxlZCI6ICIxIiwgCiAgICAiWC1CMy1TcGFuaWQiOiAiZDEwYTI2OWM1YjA1ZWM3ZSIsIAogICAgIlgtQjMtVHJhY2VpZCI6ICJjZWE3OTJmZjA1N2UxYmNkYzM4YzY5Y2IwYWRiMzZmZCIsIAogICAgIlgtRW52b3ktQXR0ZW1wdC1Db3VudCI6ICIxIiwgCiAgICAiWC1Gb3J3YXJkZWQtQ2xpZW50LUNlcnQiOiAiQnk9c3BpZmZlOi8vY2x1c3Rlci5sb2NhbC9ucy90cmFjZXMtdGVzdC9zYS9odHRwYmluO0hhc2g9NmMyYjE5M2Y1ZmJhMGEyZjM4ZjU0MDcwYTZiZDAwNzRlZGJjYmVkZTc4ODM5ODBiYWEyZjY2ODEyZTQ2Mjg4ZTtTdWJqZWN0PVwiXCI7VVJJPXNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMvdHJhY2VzLXRlc3Qvc2EvY3VybCIKICB9Cn0K",
+      "TruncatedBody": false
+    }
   }
 }

--- a/backend/pkg/test/trace_files/httpbin_get_user_agent.json
+++ b/backend/pkg/test/trace_files/httpbin_get_user_agent.json
@@ -1,68 +1,73 @@
 {
-  "request_id": "a0f979bc-f9a6-981a-b899-3b720bf0447c",
+  "requestID": "a0f979bc-f9a6-981a-b899-3b720bf0447c",
   "scheme": "",
-  "destination_address": "10.116.207.196:8000",
-  "source_address": "10.116.207.197:8000",
-  "scnt_request": {
+  "destinationAddress": "10.116.207.196:8000",
+  "destinationNamespace": null,
+  "sourceAddress": "10.116.207.197:8000",
+  "request": {
     "method": "GET",
     "path": "/user-agent",
     "host": "",
-    "version": "",
-    "headers": [
-      [
-        "host",
-        "httpbin:8000"
+    "common": {
+      "version": null,
+      "headers": [
+        {
+          "key": "host",
+          "value": "httpbin:8000"
+        },
+        {
+          "key": "user-agent",
+          "value": "curl/7.35.0"
+        },
+        {
+          "key": "accept",
+          "value": "application/json"
+        },
+        {
+          "key": "x-forwarded-proto",
+          "value": "http"
+        },
+        {
+          "key": "x-request-id",
+          "value": "a0f979bc-f9a6-981a-b899-3b720bf0447c"
+        }
       ],
-      [
-        "user-agent",
-        "curl/7.35.0"
-      ],
-      [
-        "accept",
-        "application/json"
-      ],
-      [
-        "x-forwarded-proto",
-        "http"
-      ],
-      [
-        "x-request-id",
-        "a0f979bc-f9a6-981a-b899-3b720bf0447c"
-      ]
-    ],
-    "body": "",
-    "truncated_body": false
+      "body": "",
+      "TruncatedBody": false
+    }
   },
-  "scnt_response": {
-    "status_code": "200",
-    "version": "",
-    "headers": [
-      [
-        "server",
-        "istio-envoy"
+  "response": {
+    "statusCode": "200",
+    "common": {
+      "version": "",
+      "headers": [
+        {
+          "key": "server",
+          "value": "istio-envoy"
+        },
+        {
+          "key": "date",
+          "value": "Mon, 16 Aug 2021 11:16:02 GMT"
+        },
+        {
+          "key": "content-type",
+          "value": "application/json"
+        },
+        {
+          "key": "content-length",
+          "value": "34"
+        },
+        {
+          "key": "access-control-allow-origin",
+          "value": "*"
+        },
+        {
+          "key": "access-control-allow-credentials",
+          "value": "true"
+        }
       ],
-      [
-        "date",
-        "Mon, 16 Aug 2021 11:16:02 GMT"
-      ],
-      [
-        "content-type",
-        "application/json"
-      ],
-      [
-        "content-length",
-        "34"
-      ],
-      [
-        "access-control-allow-origin",
-        "*"
-      ],
-      [
-        "access-control-allow-credentials",
-        "true"
-      ]
-    ],
-    "body": "ewogICJ1c2VyLWFnZW50IjogImN1cmwvNy4zNS4wIgp9Cg==",
-    "truncated_body": false
+      "body": "ewogICJ1c2VyLWFnZW50IjogImN1cmwvNy4zNS4wIgp9Cg==",
+      "TruncatedBody": false
+    }
   }
 }

--- a/backend/pkg/test/trace_files/httpbin_post_anything.json
+++ b/backend/pkg/test/trace_files/httpbin_post_anything.json
@@ -1,68 +1,73 @@
 {
-  "request_id": "e3ff6c72-104c-908d-bcd3-3774688fb9f1",
+  "requestID": "e3ff6c72-104c-908d-bcd3-3774688fb9f1",
   "scheme": "",
-  "destination_address": "10.116.207.196:8000",
-  "source_address": "10.116.207.197:8000",
-  "scnt_request": {
+  "destinationAddress": "10.116.207.196:8000",
+  "destinationNamespace": null,
+  "sourceAddress": "10.116.207.197:8000",
+  "request": {
     "method": "POST",
     "path": "/anything",
     "host": "",
-    "version": "",
-    "headers": [
-      [
-        "host",
-        "httpbin:8000"
+    "common": {
+      "version": null,
+      "headers": [
+        {
+          "key": "host",
+          "value": "httpbin:8000"
+        },
+        {
+          "key": "user-agent",
+          "value": "curl/7.35.0"
+        },
+        {
+          "key": "accept",
+          "value": "application/json"
+        },
+        {
+          "key": "x-forwarded-proto",
+          "value": "http"
+        },
+        {
+          "key": "x-request-id",
+          "value": "e3ff6c72-104c-908d-bcd3-3774688fb9f1"
+        }
       ],
-      [
-        "user-agent",
-        "curl/7.35.0"
-      ],
-      [
-        "accept",
-        "application/json"
-      ],
-      [
-        "x-forwarded-proto",
-        "http"
-      ],
-      [
-        "x-request-id",
-        "e3ff6c72-104c-908d-bcd3-3774688fb9f1"
-      ]
-    ],
-    "body": "",
-    "truncated_body": false
+      "body": "",
+      "TruncatedBody": false
+    }
   },
-  "scnt_response": {
-    "status_code": "200",
-    "version": "",
-    "headers": [
-      [
-        "server",
-        "istio-envoy"
+  "response": {
+    "statusCode": "200",
+    "common": {
+      "version": "",
+      "headers": [
+        {
+          "key": "server",
+          "value": "istio-envoy"
+        },
+        {
+          "key": "date",
+          "value": "Mon, 16 Aug 2021 10:42:11 GMT"
+        },
+        {
+          "key": "content-type",
+          "value": "application/json"
+        },
+        {
+          "key": "content-length",
+          "value": "738"
+        },
+        {
+          "key": "access-control-allow-origin",
+          "value": "*"
+        },
+        {
+          "key": "access-control-allow-credentials",
+          "value": "true"
+        }
       ],
-      [
-        "date",
-        "Mon, 16 Aug 2021 10:42:11 GMT"
-      ],
-      [
-        "content-type",
-        "application/json"
-      ],
-      [
-        "content-length",
-        "738"
-      ],
-      [
-        "access-control-allow-origin",
-        "*"
-      ],
-      [
-        "access-control-allow-credentials",
-        "true"
-      ]
-    ],
-    "body": "ewogICJhcmdzIjoge30sIAogICJkYXRhIjogIiIsIAogICJmaWxlcyI6IHt9LCAKICAiZm9ybSI6IHt9LCAKICAiaGVhZGVycyI6IHsKICAgICJBY2NlcHQiOiAiYXBwbGljYXRpb24vanNvbiIsIAogICAgIkNvbnRlbnQtTGVuZ3RoIjogIjAiLCAKICAgICJIb3N0IjogImh0dHBiaW46ODAwMCIsIAogICAgIlVzZXItQWdlbnQiOiAiY3VybC83LjM1LjAiLCAKICAgICJYLUIzLVBhcmVudHNwYW5pZCI6ICJhNDc0YTY0OGFhOGUzOGMyIiwgCiAgICAiWC1CMy1TYW1wbGVkIjogIjEiLCAKICAgICJYLUIzLVNwYW5pZCI6ICIzZmUxZmZmNGI1MDkxYmM0IiwgCiAgICAiWC1CMy1UcmFjZWlkIjogImVmNjg4NzdkOTAxZjMzZjRhNDc0YTY0OGFhOGUzOGMyIiwgCiAgICAiWC1FbnZveS1BdHRlbXB0LUNvdW50IjogIjEiLCAKICAgICJYLUZvcndhcmRlZC1DbGllbnQtQ2VydCI6ICJCeT1zcGlmZmU6Ly9jbHVzdGVyLmxvY2FsL25zL3RyYWNlcy10ZXN0L3NhL2h0dHBiaW47SGFzaD02YzJiMTkzZjVmYmEwYTJmMzhmNTQwNzBhNmJkMDA3NGVkYmNiZWRlNzg4Mzk4MGJhYTJmNjY4MTJlNDYyODhlO1N1YmplY3Q9XCJcIjtVUkk9c3BpZmZlOi8vY2x1c3Rlci5sb2NhbC9ucy90cmFjZXMtdGVzdC9zYS9jdXJsIgogIH0sIAogICJqc29uIjogbnVsbCwgCiAgIm1ldGhvZCI6ICJQT1NUIiwgCiAgIm9yaWdpbiI6ICIxMjcuMC4wLjYiLCAKICAidXJsIjogImh0dHA6Ly9odHRwYmluOjgwMDAvYW55dGhpbmciCn0K",
-    "truncated_body": false
+      "body": "ewogICJhcmdzIjoge30sIAogICJkYXRhIjogIiIsIAogICJmaWxlcyI6IHt9LCAKICAiZm9ybSI6IHt9LCAKICAiaGVhZGVycyI6IHsKICAgICJBY2NlcHQiOiAiYXBwbGljYXRpb24vanNvbiIsIAogICAgIkNvbnRlbnQtTGVuZ3RoIjogIjAiLCAKICAgICJIb3N0IjogImh0dHBiaW46ODAwMCIsIAogICAgIlVzZXItQWdlbnQiOiAiY3VybC83LjM1LjAiLCAKICAgICJYLUIzLVBhcmVudHNwYW5pZCI6ICJhNDc0YTY0OGFhOGUzOGMyIiwgCiAgICAiWC1CMy1TYW1wbGVkIjogIjEiLCAKICAgICJYLUIzLVNwYW5pZCI6ICIzZmUxZmZmNGI1MDkxYmM0IiwgCiAgICAiWC1CMy1UcmFjZWlkIjogImVmNjg4NzdkOTAxZjMzZjRhNDc0YTY0OGFhOGUzOGMyIiwgCiAgICAiWC1FbnZveS1BdHRlbXB0LUNvdW50IjogIjEiLCAKICAgICJYLUZvcndhcmRlZC1DbGllbnQtQ2VydCI6ICJCeT1zcGlmZmU6Ly9jbHVzdGVyLmxvY2FsL25zL3RyYWNlcy10ZXN0L3NhL2h0dHBiaW47SGFzaD02YzJiMTkzZjVmYmEwYTJmMzhmNTQwNzBhNmJkMDA3NGVkYmNiZWRlNzg4Mzk4MGJhYTJmNjY4MTJlNDYyODhlO1N1YmplY3Q9XCJcIjtVUkk9c3BpZmZlOi8vY2x1c3Rlci5sb2NhbC9ucy90cmFjZXMtdGVzdC9zYS9jdXJsIgogIH0sIAogICJqc29uIjogbnVsbCwgCiAgIm1ldGhvZCI6ICJQT1NUIiwgCiAgIm9yaWdpbiI6ICIxMjcuMC4wLjYiLCAKICAidXJsIjogImh0dHA6Ly9odHRwYmluOjgwMDAvYW55dGhpbmciCn0K",
+      "TruncatedBody": false
+    }
   }
 }

--- a/backend/pkg/test/trace_files/httpbin_post_status_code.json
+++ b/backend/pkg/test/trace_files/httpbin_post_status_code.json
@@ -1,68 +1,73 @@
 {
-  "request_id": "c44c2e8d-8f97-99c7-97ab-8ce59d7d70c2",
+  "requestID": "c44c2e8d-8f97-99c7-97ab-8ce59d7d70c2",
   "scheme": "",
-  "destination_address": "10.116.207.196:8000",
-  "source_address": "10.116.207.197:8000",
-  "scnt_request": {
+  "destinationAddress": "10.116.207.196:8000",
+  "destinationNamespace": null,
+  "sourceAddress": "10.116.207.197:8000",
+  "request": {
     "method": "POST",
     "path": "/status/code",
     "host": "",
-    "version": "",
-    "headers": [
-      [
-        "host",
-        "httpbin:8000"
+    "common": {
+      "version": null,
+      "headers": [
+        {
+          "key": "host",
+          "value": "httpbin:8000"
+        },
+        {
+          "key": "user-agent",
+          "value": "curl/7.35.0"
+        },
+        {
+          "key": "accept",
+          "value": "text/plain"
+        },
+        {
+          "key": "x-forwarded-proto",
+          "value": "http"
+        },
+        {
+          "key": "x-request-id",
+          "value": "c44c2e8d-8f97-99c7-97ab-8ce59d7d70c3"
+        }
       ],
-      [
-        "user-agent",
-        "curl/7.35.0"
-      ],
-      [
-        "accept",
-        "text/plain"
-      ],
-      [
-        "x-forwarded-proto",
-        "http"
-      ],
-      [
-        "x-request-id",
-        "c44c2e8d-8f97-99c7-97ab-8ce59d7d70c3"
-      ]
-    ],
-    "body": "",
-    "truncated_body": false
+      "body": "",
+      "TruncatedBody": false
+    }
   },
-  "scnt_response": {
-    "status_code": "200",
-    "version": "",
-    "headers": [
-      [
-        "server",
-        "istio-envoy"
+  "response": {
+    "statusCode": "200",
+    "common": {
+      "version": "",
+      "headers": [
+        {
+          "key": "server",
+          "value": "istio-envoy"
+        },
+        {
+          "key": "date",
+          "value": "Mon, 16 Aug 2021 10:46:20 GMT"
+        },
+        {
+          "key": "content-type",
+          "value": "application/json"
+        },
+        {
+          "key": "access-control-allow-origin",
+          "value": "*"
+        },
+        {
+          "key": "access-control-allow-credentials",
+          "value": "true"
+        },
+        {
+          "key": "content-length",
+          "value": "0"
+        }
       ],
-      [
-        "date",
-        "Mon, 16 Aug 2021 10:46:20 GMT"
-      ],
-      [
-        "content-type",
-        "application/json"
-      ],
-      [
-        "access-control-allow-origin",
-        "*"
-      ],
-      [
-        "access-control-allow-credentials",
-        "true"
-      ],
-      [
-        "content-length",
-        "0"
-      ]
-    ],
-    "body": "",
-    "truncated_body": false
+      "body": "",
+      "TruncatedBody": false
+    }
   }
 }

--- a/backend/pkg/test/trace_files/httpbin_post_status_codes.json
+++ b/backend/pkg/test/trace_files/httpbin_post_status_codes.json
@@ -1,68 +1,73 @@
 {
-  "request_id": "c44c2e8d-8f97-99c7-97ab-8ce59d7d70c1",
+  "requestID": "c44c2e8d-8f97-99c7-97ab-8ce59d7d70c1",
   "scheme": "",
-  "destination_address": "10.116.207.196:8000",
-  "source_address": "10.116.207.197:8000",
-  "scnt_request": {
+  "destinationAddress": "10.116.207.196:8000",
+  "destinationNamespace": null,
+  "sourceAddress": "10.116.207.197:8000",
+  "request": {
     "method": "POST",
     "path": "/status/200",
     "host": "",
-    "version": "",
-    "headers": [
-      [
-        "host",
-        "httpbin:8000"
+    "common": {
+      "version": null,
+      "headers": [
+        {
+          "key": "host",
+          "value": "httpbin:8000"
+        },
+        {
+          "key": "user-agent",
+          "value": "curl/7.35.0"
+        },
+        {
+          "key": "accept",
+          "value": "text/plain"
+        },
+        {
+          "key": "x-forwarded-proto",
+          "value": "http"
+        },
+        {
+          "key": "x-request-id",
+          "value": "c44c2e8d-8f97-99c7-97ab-8ce59d7d70c3"
+        }
       ],
-      [
-        "user-agent",
-        "curl/7.35.0"
-      ],
-      [
-        "accept",
-        "text/plain"
-      ],
-      [
-        "x-forwarded-proto",
-        "http"
-      ],
-      [
-        "x-request-id",
-        "c44c2e8d-8f97-99c7-97ab-8ce59d7d70c3"
-      ]
-    ],
-    "body": "",
-    "truncated_body": false
+      "body": "",
+      "TruncatedBody": false
+    }
   },
-  "scnt_response": {
-    "status_code": "200",
-    "version": "",
-    "headers": [
-      [
-        "server",
-        "istio-envoy"
+  "response": {
+    "statusCode": "200",
+    "common": {
+      "version": "",
+      "headers": [
+        {
+          "key": "server",
+          "value": "istio-envoy"
+        },
+        {
+          "key": "date",
+          "value": "Mon, 16 Aug 2021 10:46:20 GMT"
+        },
+        {
+          "key": "content-type",
+          "value": "application/json"
+        },
+        {
+          "key": "access-control-allow-origin",
+          "value": "*"
+        },
+        {
+          "key": "access-control-allow-credentials",
+          "value": "true"
+        },
+        {
+          "key": "content-length",
+          "value": "0"
+        }
       ],
-      [
-        "date",
-        "Mon, 16 Aug 2021 10:46:20 GMT"
-      ],
-      [
-        "content-type",
-        "application/json"
-      ],
-      [
-        "access-control-allow-origin",
-        "*"
-      ],
-      [
-        "access-control-allow-credentials",
-        "true"
-      ],
-      [
-        "content-length",
-        "0"
-      ]
-    ],
-    "body": "",
-    "truncated_body": false
+      "body": "",
+      "TruncatedBody": false
+    }
   }
 }


### PR DESCRIPTION
Format of traces was recently changed.
It was not updated in the example traces files.

```shell
jq '{requestID: .request_id,
     scheme: .scheme,
     destinationAddress: .destination_address,
     destinationNamespace: .destination_namespace,
     sourceAddress: .source_address,
     request: {
       method: .scnt_request.method,
       path: .scnt_request.path,
       host: .scnt_request.host,
       common: {
         version: .scnt.request.version,
         headers: [.scnt_request.headers[]? | {key: .[0], value: .[1]}],
         body: .scnt_request.body,
         TruncatedBody: .scnt_request.truncated_body
       }
     },
     response: {
       statusCode: .scnt_response.status_code,
       common: {
         version: .scnt_response.version,
         headers: [.scnt_response.headers[]? | {key: .[0], value: .[1]}],
         body: .scnt_response.body,
         TruncatedBody: .scnt_response.truncated_body
       }
     }
    }' old_trace_format.json
```